### PR TITLE
make subdirs for other nginx caches to avoid permissions errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,10 @@ RUN groupadd nginx \
     && useradd -ms /bin/sh -g nginx nginx \
     && mkdir /var/cache/nginx \
     && mkdir /var/cache/nginx/client_temp \
+    && mkdir /var/cache/nginx/proxy_temp \
+    && mkdir /var/cache/nginx/fastcgi_temp \
+    && mkdir /var/cache/nginx/uwsgi_temp \
+    && mkdir /var/cache/nginx/scgi_temp \
     && chmod -R 766 /var/log/nginx /var/cache/nginx \
     && chmod 644 /etc/nginx/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN groupadd nginx \
     && mkdir /var/cache/nginx/fastcgi_temp \
     && mkdir /var/cache/nginx/uwsgi_temp \
     && mkdir /var/cache/nginx/scgi_temp \
-    && chmod -R 766 /var/log/nginx /var/cache/nginx \
+    && chmod -R 777 /var/log/nginx /var/cache/nginx \
     && chmod 644 /etc/nginx/*
 
 CMD ["dockerize","-stdout","/var/log/nginx/access.log","-stderr","/var/log/nginx/error.log","/usr/sbin/nginx","-g","daemon off;"]


### PR DESCRIPTION
I believe this error:

```
2018/09/08 15:47:40 [crit] 17#17: *39 open() "/var/cache/nginx/uwsgi_temp/3/00/0000000003" failed (13: Permission denied) while reading upstream, client: x.x.x.x, server: localhost, request: "GET /search/?q=def HTTP/1.1", upstream: "uwsgi://x.x.x.x:9090", host: "x.x.x.x"
```

happens because the other subdirs in `/var/cache/nginx` weren't created, so the `chmod` in the `Dockerfile` doesn't set them to `766` like it does for `/var/cache/nginx/client_temp`, note the rest of the directories have `700`, not `766`:

```
root@0a15196b52ef:/# ls -l /var/cache/nginx/
total 20
drwxrw-rw- 1 nginx root 4096 Nov 11  2016 client_temp
drwx------ 2 nginx root 4096 Sep  8 17:13 fastcgi_temp
drwx------ 2 nginx root 4096 Sep  8 17:13 proxy_temp
drwx------ 2 nginx root 4096 Sep  8 17:13 scgi_temp
drwx------ 2 nginx root 4096 Sep  8 17:13 uwsgi_temp
```